### PR TITLE
Update exports for Typescript 2.6

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,8 @@ export class GremlinClient extends EventEmitter {
   readable (script: string): Readable;
   readable (script: string, bindings: Bindings): Readable;
   readable (script: string, bindings: Bindings, message: any): Readable;
+
+  closeConnection() : void;
 }
 
 export interface ClientOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,5 +95,3 @@ export interface BoundFunctions {
 }
 
 export function bindForClient (client: GremlinClient, functions: Functions): BoundFunctions;
-
-export default { createClient, makeTemplateTag, bindForClient };


### PR DESCRIPTION
Typescript 2.6+ does not allow the default export that's currently in these types, so this PR removes the default export. 

If it's preferred, I could also add a default export class or namespace which contains the 3 functions the original did to maintain backwards compatibility for anyone using the default export.

I also added the `closeConnection()` method to the `GremlinClient` so you can actually close the connection in Typescript without using a type assertion as a workaround.